### PR TITLE
Small POD fixes to satisfy podchecker.

### DIFF
--- a/lib/Storable/AMF.pm
+++ b/lib/Storable/AMF.pm
@@ -109,7 +109,6 @@ Storable::AMF - serializing/deserializing AMF0/AMF3 data
   $bytea = Storable::AMF3::freeze( ... );
 
   ...
-=cut
 
 =head1 DESCRIPTION
 
@@ -117,22 +116,17 @@ This module is (de)serializer for Adobe's AMF0/AMF3 (Action Message Format ver 0
 To deserialize AMF3 objects you can export function from Storable::AMF3 package
 Almost all function implemented in XS/C for speed, except file operation. 
 
-=cut
 =head1 MOTIVATION
 
 Speed, simplicity and agile. 
 
-=cut
 =head1 BENCHMARKS
 
 	About 50-60 times faster than Data::AMF pure perl module. (2009)
 	About 40% faster than Storable in big objects.        (2009)
 	About 6 times faster than Storable for small object    (2009)
 
-=cut
-
 =head1 FUNCTIONS
-=cut
 
 =over
 
@@ -155,7 +149,7 @@ Speed, simplicity and agile.
 
 =item $perl_time = perl_date( $date_member )
 	Converts value from AMF date to perl timestampr, can croak.
-	
+
 =item store $obj, $file
   --- Store serialized AMF0 data to file
 
@@ -184,19 +178,15 @@ Speed, simplicity and agile.
   --- test if object contain lost memory fragments inside.
   (Example do { my $a = []; @$a=$a; $a})
 
-=item parse_serializator_option
-=item parse_option
+=item parse_serializator_option / parse_option
   generate option scalar for freeze/thaw/deparse_amf
   See L<Storable::AMF0> for complete list of options
 
 =back
 
 =head1 EXPORT
-  
+
   None by default.
-
-=cut
-
 
 =head1 LIMITATION
 
@@ -204,7 +194,6 @@ At current moment and with restriction of AMF0/AMF3 format referrences to scalar
 and can't/ may not serialize tied variables.
 And dualvars (See Scalar::Util) are serialized as string value.
 Freezing CODEREF, IO, Regexp, GLOB referenses are restricted.
-
 
 =head1 SEE ALSO
 
@@ -226,4 +215,3 @@ Copyright (C) 2011 by A. G. Grishaev
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.8 or,
 at your option, any later version of Perl 5 you may have available.
-=cut

--- a/lib/Storable/AMF/Mapper.pm
+++ b/lib/Storable/AMF/Mapper.pm
@@ -33,6 +33,10 @@ sub new{
 	}
 	return $option_int;
 }
+
+1;
+__END__
+
 =head1 SYNOPSYS 
 
   use Storable::AMF::Mapper;
@@ -50,15 +54,6 @@ sub new{
 
   my $obj  = thaw( $amf0 ); # $obj = { Zeta=> , some_key_to_be_added => "Key Value" }
 
-
-=cut 
-
 =head1 NOTICE
-  
+
   This Mapper is experimental feature of Storable::AMF distro. So may change in future ...
-
-=cut 
-
-
-
-1;

--- a/lib/Storable/AMF0.pm
+++ b/lib/Storable/AMF0.pm
@@ -137,7 +137,6 @@ sub ref_lost_memory($) {
 
 1;
 __END__
-# Below is stub documentation for your module. You'd better edit it!
 
 =head1 NAME
 
@@ -200,8 +199,6 @@ Storable::AMF0 - serializing/deserializing AMF0 data
   $obj = thaw( $amf, $options );
   $amf = freeze( $obj, $options );
 
-=cut
-
 =head1 DESCRIPTION
 
 This module is (de)serializer for Adobe's AMF0/AMF3 (Action Message Format ver 0-3).
@@ -209,16 +206,11 @@ This is only module and it recognize only AMF0 data.
 Almost all function implemented in C for speed. 
 And some cases faster then Storable( for me always)
 
-=cut
-
 =head1 EXPORT
-  
+
   None by default.
 
-=cut
-
 =head1 FUNCTIONS
-=cut
 
 =over
 
@@ -261,10 +253,9 @@ And some cases faster then Storable( for me always)
   Return one object and number of bytes readed
   if scalar context return object
 
-=item parse_option( $option_string )
-=item parse_serializator_option( $option_string )
+=item parse_serializator_option( $option_string ) / parse_option( $option_string )
   --- generate option scalar from string usefull for some options of thaw/freeze/deparse_amf 
-	
+
 
 =back
 
@@ -294,8 +285,6 @@ And some cases faster then Storable( for me always)
 =item utf8_encode
 
 =back
-
-=cut
 
 =head1 LIMITATION
 
@@ -329,4 +318,3 @@ Copyright (C) 2011 by A. G. Grishaev
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.8 or,
 at your option, any later version of Perl 5 you may have available.
-=cut

--- a/lib/Storable/AMF3.pm
+++ b/lib/Storable/AMF3.pm
@@ -73,7 +73,6 @@ sub lock_store($$) {
 }};
 1;
 __END__
-# Below is stub documentation for your module. You'd better edit it!
 
 =head1 NAME
 
@@ -110,8 +109,6 @@ Storable::AMF3 - serializing/deserializing AMF3 data
   - or -
   $obj = deparse_amf( freeze($a1) . freeze($a) ... );
 
-=cut
-
 =head1 DESCRIPTION
 
 This module is (de)serializer for Adobe's AMF3 (Action Message Format ver 3).
@@ -119,16 +116,11 @@ This is only module and it recognize only AMF3 data.
 Almost all function implemented in C for speed. 
 And some cases faster then Storable( for me always)
 
-=cut
-
 =head1 EXPORT
-  
+
   None by default.
 
-=cut
-
 =head1 FUNCTIONS
-=cut
 
 =over
 
@@ -171,8 +163,7 @@ And some cases faster then Storable( for me always)
   Return one object and number of bytes readed
   if scalar context return object
 
-=item parse_option
-=item parse_serializator_option
+=item parse_serializator_option / parse_option
   generate option scalar for freeze/thaw/deparse_amf
   See L<Storable::AMF0> for complete list of options
 
@@ -199,4 +190,3 @@ Copyright (C) 2011 by A. G. Grishaev
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.8 or,
 at your option, any later version of Perl 5 you may have available.
-=cut


### PR DESCRIPTION
I noticed a few warnings and errors from podchecker (output below) so I tried cleaning it up a bit.

Thanks,
Kevin

```
$ podchecker AMF.pm AMF0.pm AMF3.pm AMF/Mapper.pm
*** ERROR: Apparent command =cut not preceded by blank line at line 112 in file AMF.pm
*** ERROR: Spurious text after =cut at line 120 in file AMF.pm
*** ERROR: Spurious text after =cut at line 125 in file AMF.pm
*** ERROR: Spurious =cut command at line 125 in file AMF.pm
*** ERROR: Spurious =cut command at line 132 in file AMF.pm
*** ERROR: Apparent command =cut not preceded by blank line at line 135 in file AMF.pm
*** WARNING: line containing nothing but whitespace in paragraph at line 158 in file AMF.pm
*** ERROR: Apparent command =item not preceded by blank line at line 188 in file AMF.pm
*** WARNING: line containing nothing but whitespace in paragraph at line 195 in file AMF.pm
*** ERROR: Apparent command =cut not preceded by blank line at line 229 in file AMF.pm
AMF.pm has 8 pod syntax errors.
*** WARNING: line containing nothing but whitespace in paragraph at line 215 in file AMF0.pm
*** ERROR: Apparent command =cut not preceded by blank line at line 221 in file AMF0.pm
*** ERROR: Apparent command =item not preceded by blank line at line 265 in file AMF0.pm
*** WARNING: line containing nothing but whitespace in paragraph at line 267 in file AMF0.pm
*** ERROR: Apparent command =cut not preceded by blank line at line 332 in file AMF0.pm
AMF0.pm has 3 pod syntax errors.
*** WARNING: line containing nothing but whitespace in paragraph at line 125 in file AMF3.pm
*** ERROR: Apparent command =cut not preceded by blank line at line 131 in file AMF3.pm
*** ERROR: Apparent command =item not preceded by blank line at line 175 in file AMF3.pm
*** ERROR: Apparent command =cut not preceded by blank line at line 202 in file AMF3.pm
AMF3.pm has 3 pod syntax errors.
*** ERROR: Spurious =cut command at line 54 in file AMF/Mapper.pm
*** WARNING: line containing nothing but whitespace in paragraph at line 57 in file AMF/Mapper.pm
AMF/Mapper.pm has 1 pod syntax error.
```
